### PR TITLE
Notify only if the email and settings of the author are OK

### DIFF
--- a/app/services/voting_booth.rb
+++ b/app/services/voting_booth.rb
@@ -37,7 +37,16 @@ class VotingBooth
       hater_count: @movie.haters.size)
   end
 
+  # Notifies the author of the movie for a like
+  #   only if her settings are allowing to do it
+  #   and her email address is updated
   def _notify_for_like
+    # 0. Checks
+    return unless @movie.user # User must be present
+    return unless @movie.user.notify_for_like # User must have chosen in her settings to be notified by email
+    return unless @movie.user.email # User must have an email address
+
+    # 1. Send the email
     # NotificationsMailer.delay(:queue => 'user_notifications').notify_user_for_like(movie_id:, liker_id:)
     NotificationsMailer.notify_user_for_like(movie_id: @movie.id, liker_id: @user.id).deliver
   end

--- a/db/users.yml
+++ b/db/users.yml
@@ -1,9 +1,15 @@
 - name: John McFoo
   uid:  'null|johnmcfoo'
+  email: john@example.xom
+  notify_for_like: true
+
 - name: Alice Wallace
   uid:  'null|alice'
+  email: alice@example.com
+  notify_for_like: false
+
 - name: Bob Ablleton
   uid:  'null|bob'
+
 - name: Charlie O'Callaghan
   uid:  'null|charlie'
-


### PR DESCRIPTION
- Amend acceptance tests for missing email and `notify_for_like=false`
- Implement the checks

== Trello Issues

- https://trello.com/c/Z91rHj21/18-check-that-user-has-selected-to-be-notified-before-sending-the-email-after-a-like
- https://trello.com/c/liEEBptL/16-email-notification-errors-out-when-user-does-not-provide-his-email-address-through-github